### PR TITLE
0.1.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.1.2 - 2025-07-22
+### Changed
+- Change Script: mcp_server -> bq_mcp_server
+
+
 ## 0.1.1 - 2025-07-22
 ### Changed
 - Organized dependency libraries

--- a/README-ja.md
+++ b/README-ja.md
@@ -30,6 +30,19 @@ Google Cloud BigQueryのデータセット、テーブル、スキーマ情報�
 - Google Cloud Platformアカウント
 - BigQuery APIが有効化されたGCPプロジェクト
 
+### インストール
+uv
+
+```bash
+uv add bq_mcp_server
+```
+
+pip
+
+```bash
+pip install bq_mcp_server
+```
+
 ### 依存関係のインストール
 
 本プロジェクトではパッケージ管理に`uv`を使用しています：
@@ -60,7 +73,7 @@ uv sync
                 "run",
                 "--directory",
                 "<your install directory>",
-                "mcp_server"
+                "bq_mcp_server"
             ],
             "env": {
                 "PYTHONPATH": "<your install directory>",
@@ -102,7 +115,7 @@ pytest --cov=bq_mcp_server
 ### MCPサーバーの起動
 
 ```bash
-uv run mcp_server
+uv run bq_mcp_server
 ```
 
 ### FastAPI REST APIサーバーの起動

--- a/README.md
+++ b/README.md
@@ -23,12 +23,24 @@ Available tools:
 5. `check_query_scan_amount` - Retrieves the scan amount for BigQuery SQL queries
 
 ## Installation and Environment Setup
-
 ### Prerequisites
 
 - Python 3.11 or later
 - Google Cloud Platform account
 - GCP project with BigQuery API enabled
+
+### Install
+uv
+
+```bash
+uv add bq_mcp_server
+```
+
+pip
+
+```bash
+pip install bq_mcp_server
+```
 
 ### Installing Dependencies
 
@@ -60,7 +72,7 @@ For a list of configuration values, see:
                 "run",
                 "--directory",
                 "<your install directory>",
-                "mcp_server"
+                "bq_mcp_server"
             ],
             "env": {
                 "PYTHONPATH": "<your install directory>",
@@ -102,7 +114,7 @@ pytest --cov=bq_mcp_server
 ### Starting the MCP Server
 
 ```bash
-uv run mcp_server
+uv run bq_mcp_server
 ```
 
 ### Starting the FastAPI REST API Server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "bq_mcp_server"
 authors = [
     {name = "takada-at", email = "takada-at@klab.com"}
 ]
-version = "0.1.1"
+version = "0.1.2"
 license = {file = "LICENSE"}
 description = "Python-based MCP (Model Context Protocol) server that retrieves dataset, table, and schema information from Google Cloud BigQuery"
 readme = "README.md"
@@ -45,7 +45,7 @@ exclude = [
 ]
 
 [project.scripts]
-mcp_server = "bq_mcp_server.adapters.mcp_server:main"
+bq_mcp_server = "bq_mcp_server.adapters.mcp_server:main"
 
 [project.urls]
 Homepage = "https://github.com/takada-at/bq_mcp_server"


### PR DESCRIPTION
feat: パッケージのスクリプト名をbq_mcp_serverに変更し、インストール手順を追加

パッケージの使いやすさを向上させるため、以下の変更を実施：

- pyproject.tomlのスクリプト名をmcp_server → bq_mcp_serverに変更
- README（日本語・英語）にuvとpipを使用したインストール手順を追加
- ドキュメント内のコマンド例を新しいスクリプト名に更新
- バージョンを0.1.1から0.1.2に更新

この変更により、パッケージ名とスクリプト名の一貫性が向上し、
ユーザーがより直感的にコマンドを実行できるようになります。